### PR TITLE
Added option for setting key creation directory

### DIFF
--- a/bin/create_tls_key.sh
+++ b/bin/create_tls_key.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
-set -xe
+set -e
 
-mkdir -p ~/.irslackd
-openssl req -newkey rsa:4096 -nodes -sha512 -x509 -days 3650 -nodes -out ~/.irslackd/cert.pem -keyout ~/.irslackd/pkey.pem
-fingerprint=$(openssl x509 -noout -fingerprint -sha512 -inform pem -in ~/.irslackd/cert.pem | cut -d= -f2-)
+while getopts ":d:" opt; do
+  case $opt in
+    d) dir="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+if [ -z "$dir" ]; then
+   dir="~/.irslackd"
+fi
+dir=$(eval echo $dir)
+
+mkdir -p $dir
+set -x
+openssl req -newkey rsa:4096 -nodes -sha512 -x509 -days 3650 -nodes -out $dir/cert.pem -keyout $dir/pkey.pem
+fingerprint=$(openssl x509 -noout -fingerprint -sha512 -inform pem -in $dir/cert.pem | cut -d= -f2-)
 echo -e "\nFingerprint: $(echo $fingerprint | tr -d ':')"


### PR DESCRIPTION
This commit adds the ability to choose the directory where the private TLS key and certificate will be created by passing an optional parameter `-d <directory>` example:
`./bin/create_tls_key.sh -d /opt/irslackd`